### PR TITLE
Added Glob/Regex support for position calibration lists and some smaller fixes and features

### DIFF
--- a/hdtv/app.py
+++ b/hdtv/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # HDTV - A ROOT-based spectrum analysis software
 #  Copyright (C) 2006-2019  The HDTV development team (see file AUTHORS)

--- a/hdtv/histogram.py
+++ b/hdtv/histogram.py
@@ -17,6 +17,7 @@
 # along with HDTV; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
+import copy
 import os
 
 from scipy.interpolate import InterpolatedUnivariateSpline
@@ -28,10 +29,10 @@ import hdtv.rootext.mfile
 import hdtv.rootext.calibration
 import hdtv.rootext.display
 import hdtv.rootext.fit
+import hdtv.cal
 
 from hdtv.drawable import Drawable
 from hdtv.specreader import SpecReader, SpecReaderError
-from hdtv.cal import CalibrationFitter
 from hdtv.util import LockViewport
 
 # Don't add created spectra to the ROOT directory
@@ -231,8 +232,11 @@ class Histogram(Drawable):
             self.displayObj.SetHist(self._hist)
         # update calibration
         if calibrate:
-            if not self.cal:
-                self.cal.SetCal(0.0, 1.0)
+            if self.cal:
+                # Copy to not modify the cal in the position calibration cal dict
+                self.cal = copy.copy(self.cal)
+            else:
+                self.cal = hdtv.cal.MakeCalibration((0, 1))
             self.cal.Rebin(ngroup)
             self.displayObj.SetCal(self.cal)
             hdtv.ui.info("Calibration updated for rebinned spectrum")
@@ -310,10 +314,12 @@ class Histogram(Drawable):
 
         self._hist = newhist
         if use_tv_binning:
-            if binsize != 1.0 or self.cal:
-                self.cal.SetCal(0, binsize)
+            if binsize == 1.0:
+                self.cal = None
+            else:
+                self.cal = hdtv.cal.MakeCalibration((0, binsize))
         else:
-            self.cal.SetCal(binsize / 2, binsize)
+            self.cal = hdtv.cal.MakeCalibration((binsize / 2, binsize))
         # update display
         if self.displayObj:
             self.displayObj.SetHist(self._hist)
@@ -389,7 +395,7 @@ class Histogram(Drawable):
                 hist.GetName(), hist.GetTitle(), hist.GetNbinsX(), 0, hist.GetNbinsX()
             )
             if caldegree:
-                cf = CalibrationFitter()
+                cf = hdtv.cal.CalibrationFitter()
             # TODO: Slow
             for bin in range(0, hist.GetNbinsX()):
                 if caldegree:

--- a/hdtv/histogram.py
+++ b/hdtv/histogram.py
@@ -138,6 +138,7 @@ class Histogram(Drawable):
             s += "Calibration: none\n"
         elif isinstance(self.cal, ROOT.HDTV.Calibration):
             s += "Calibration: Polynomial, degree %d\n" % self.cal.GetDegree()
+            s += f"Calibration coefficients: {hdtv.cal.PrintCal(self.cal)}\n"
         else:
             s += "Calibration: unknown\n"
         return s

--- a/hdtv/plugins/calInterface.py
+++ b/hdtv/plugins/calInterface.py
@@ -1491,20 +1491,23 @@ class EnergyCalHDTVInterface:
             return
         # update calcdict of main session
         self.spectra.caldict.update(caldict)
-        for name in caldict.keys():
-            for sid in self.spectra.dict.keys():
-                if self.spectra.dict[sid].name == name:
-                    cal = caldict[name]
-                    self.spectra.ApplyCalibration([sid], cal)
+        for specId, spec in self.spectra.dict.items():
+            try:
+                cal = self.spectra.caldict[spec.name]
+            except KeyError:
+                pass
+            else:
+                self.spectra.ApplyCalibration([specId], cal, storeInCaldict=False)
 
     def CalPosListClear(self, args):
         """
         Clear list of name <-> calibration pairs
         """
-        for name in list(self.spectra.caldict.keys()):
-            for sid in self.spectra.dict.keys():
-                if self.spectra.dict[sid].name == name:
-                    self.spectra.ApplyCalibration([sid], None)
+        for specId, spec in self.spectra.dict.items():
+            if (
+                self.spectra.caldict.get(spec.name) is not None
+            ):  # Use get() instead of "key in dict", as the latter only checks for literally matching keys, while get() also considers glob/regex matches
+                self.spectra.ApplyCalibration([specId], None)
         self.spectra.caldict.clear()
 
 

--- a/hdtv/plugins/rootInterface.py
+++ b/hdtv/plugins/rootInterface.py
@@ -394,9 +394,9 @@ class RootFileInterface:
                         self.caldict[spec.name] = spec.cal
                     else:
                         if args.load_cal:
-                            if spec.name in self.spectra.caldict:
+                            try:
                                 spec.cal = self.caldict[spec.name]
-                            else:
+                            except KeyError:
                                 hdtv.ui.warning(
                                     "No calibration found for %s" % spec.name
                                 )

--- a/hdtv/plugins/specInterface.py
+++ b/hdtv/plugins/specInterface.py
@@ -346,7 +346,9 @@ class TvSpecInterface:
         description = "Write a single spectrum to the filesystem (using libmfile)"
         parser = hdtv.cmdline.HDTVOptionParser(prog=prog, description=description)
         parser.add_argument("filename", help="filename of output file")
-        parser.add_argument("format", help="format of spectrum file")
+        parser.add_argument(
+            "format", help="format of spectrum file (e.g. txt for simple text file)"
+        )
         parser.add_argument(
             "specid", nargs="?", default=None, help="id of spectrum to write"
         )

--- a/hdtv/plugins/specInterface.py
+++ b/hdtv/plugins/specInterface.py
@@ -181,8 +181,10 @@ class SpecInterface:
                     else:
                         sid = self.spectra.Insert(spec, ID)
                         spec.color = hdtv.color.ColorForID(sid.major)
-                        if spec.name in list(self.spectra.caldict.keys()):
+                        try:
                             spec.cal = self.spectra.caldict[spec.name]
+                        except KeyError:
+                            pass
                         loaded.append(spec)
                         if fmt is None:
                             hdtv.ui.msg(f"Loaded {fname} into {sid}")

--- a/hdtv/plugins/textInterface.py
+++ b/hdtv/plugins/textInterface.py
@@ -60,6 +60,9 @@ class TextInterface(hdtv.ui.SimpleUI):
         self.opt["ui.pager.builtin"] = hdtv.options.Option(
             default=True, parse=hdtv.options.parse_bool
         )  # use built-in pager instead of external program
+        self.opt["ui.pager.disable_pager"] = hdtv.options.Option(
+            default=False, parse=hdtv.options.parse_bool
+        )  # whether to not use pager at all
 
         for (key, opt) in list(self.opt.items()):
             hdtv.options.RegisterOption(key, opt)
@@ -136,7 +139,7 @@ class TextInterface(hdtv.ui.SimpleUI):
             html = escape(text)
         lines = len(html.splitlines())
 
-        if lines > self.canvasheight:
+        if lines > self.canvasheight and not hdtv.options.Get("ui.pager.disable_pager"):
             self.page(html, end)
         else:
             super().msg(html=html, end=end)

--- a/hdtv/session.py
+++ b/hdtv/session.py
@@ -53,11 +53,11 @@ class Session(DrawableManager):
         self.workCut = Cut()
         self.workCut.active = True
         self.workCut.Draw(self.viewport)
-        self.caldict = dict()
+        self.caldict = hdtv.cal.PositionCalibrationDict()
         # main session is always active
         self._active = True
 
-    def ApplyCalibration(self, specIDs, cal):
+    def ApplyCalibration(self, specIDs, cal, storeInCaldict: bool = True):
         """
         Apply calibration cal to spectra with ids
         """
@@ -79,7 +79,8 @@ class Session(DrawableManager):
                 else:
                     hdtv.ui.msg("Calibrated spectrum with id %s" % ID)
                     cal = hdtv.cal.MakeCalibration(cal)
-                    self.caldict[spec.name] = cal
+                    if storeInCaldict:
+                        self.caldict[spec.name] = cal
                     spec.cal = cal
                 if self.workFit.spec == spec:
                     self.workFit.cal = cal
@@ -364,5 +365,5 @@ class Session(DrawableManager):
         self.workFit = Fit(Fitter(peakModel="theuerkauf", backgroundModel="polynomial"))
         self.workFit.active = True
         self.workFit.Draw(self.viewport)
-        self.caldict = dict()
+        self.caldict = hdtv.cal.PositionCalibrationDict()
         return super().Clear()

--- a/hdtv/util.py
+++ b/hdtv/util.py
@@ -352,7 +352,8 @@ class Table:
             )
         else:
             self.data.sort(
-                key=lambda x: natural_sort_key(str(x[sortBy])), reverse=reverseSort
+                key=lambda x: natural_sort_key(str(x[sortBy]).strip()),
+                reverse=reverseSort,
             )
 
     def calc_width(self):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import versioneer
 from setuptools import setup

--- a/tests/efficiency/test_wieden.py
+++ b/tests/efficiency/test_wieden.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import hdtv.efficiency as eff

--- a/tests/efficiency/test_wunder.py
+++ b/tests/efficiency/test_wunder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import hdtv.efficiency as eff

--- a/tests/integral/inttest.py
+++ b/tests/integral/inttest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/tests/mat/mattest.py
+++ b/tests/mat/mattest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import struct
 import os

--- a/tests/peak/errtest.py
+++ b/tests/peak/errtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # HDTV - A ROOT-based spectrum analysis software
 #  Copyright (C) 2006-2009  The HDTV development team (see file AUTHORS)

--- a/tests/peak/fittest.py
+++ b/tests/peak/fittest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # HDTV - A ROOT-based spectrum analysis software
 #  Copyright (C) 2006-2009  The HDTV development team (see file AUTHORS)

--- a/tests/ui/test_table.py
+++ b/tests/ui/test_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 from hdtv.ui import *


### PR DESCRIPTION
HDTV now has a new config setting `calibration.position.list.spec_name_matching` which allows to enable the use of either globs (*, ?, [], ...) or regex in the spectrum name of position calibration lists (typically read via calibration position list read FILE).
This can be useful if one has many spectra originating from the same detector, e.g. instead of

> run100_Det1.txt: 1.2 0.123
> run200_Det1.txt: 1.2 0.123
> run300_Det1.txt: 20.123 0.123
> run400_Det1.txt: 1.2 0.123
> ...

one could just use

> run*_Det1.txt: 1.2 0.123
> run300_Det1.txt: 1.2 0.123

as the calibration position list file.
A literal match of the spectrum name to a calibration position list entry will always be prefered over a glob, so in the example here the sudden shift of the calibration offset of only run300 can still be handled with ease.
As *, ? and [] are very unlikely to be part of a literal spectrum name, the default setting for the config option is to allow the use of globs (especially as some new-to-hdtv-but-tech-proficient users could even just expect globs to work for cal lists as they do for spectrum get).

Furthermore, `spectrum rebin -c` and `spectrum calbin `now don't modify a spectrum's calibration directly anymore, and instead first make a copy of it, so that the calibration entered in the global position calibration list is not altered anymore.
With this it is now possible to e.g. load the same spectrum twice and just rebin one copy of it, while the other copy's calibration stays intact.
If one is interested in the rebinned spectrum's calibration, a spectrum's calibration can now be seen via `spectrum info`.

Besides this "major" feature enabled by default, there are some minor additions and fixes involved in this pull request as well, see the individual commits for details.