### PR TITLE
Added fitting of only positive peaks, pos_lit residuals in fit list, default for fit read and some smaller fixes and features

### DIFF
--- a/hdtv/cal.py
+++ b/hdtv/cal.py
@@ -320,6 +320,7 @@ class CalibrationFitter:
 
         graph.Draw("A*")
         func.Draw("SAME")
+        canvas.Update()
 
     def DrawCalResidual(self):
         """
@@ -361,3 +362,4 @@ class CalibrationFitter:
 
         graph.Draw("A*")
         nullfunc.Draw("SAME")
+        canvas.Update()

--- a/hdtv/drawable.py
+++ b/hdtv/drawable.py
@@ -21,6 +21,7 @@ import hdtv.cal
 import hdtv.color
 import hdtv.ui
 from hdtv.util import LockViewport
+import hdtv.options
 
 
 class Drawable:
@@ -151,6 +152,9 @@ class DrawableManager:
     This class provides some handy functions to manage a collection of
     identical drawable objects.
     """
+
+    nextPrevEndBell = hdtv.options.Option(default=False, parse=hdtv.options.parse_bool)
+    hdtv.options.RegisterOption("ui.bellOnNextAndPrevIDEndReached", nextPrevEndBell)
 
     def __init__(self, viewport=None):
         self.viewport = viewport
@@ -488,6 +492,8 @@ class DrawableManager:
 
             ids.sort()
             nextIndex = (ids.index(self._iteratorID) + 1) % len(ids)
+            if nextIndex == 0 and self.nextPrevEndBell.Get():
+                print("\a", end="", flush=True)
             nextID = ids[nextIndex]
 
         except ValueError:
@@ -509,6 +515,8 @@ class DrawableManager:
 
             ids.sort()
             prevIndex = (ids.index(self._iteratorID) - 1) % len(ids)
+            if prevIndex == len(ids) - 1 and self.nextPrevEndBell.Get():
+                print("\a", end="", flush=True)
             prevID = ids[prevIndex]
         except ValueError:
             prevID = self.activeID if self.activeID is not None else self.lastID

--- a/hdtv/fitxml.py
+++ b/hdtv/fitxml.py
@@ -83,8 +83,8 @@ class FitXml:
         # <fit>
         fitElement = ET.Element("fit")
         fitElement.set("peakModel", fit.fitter.peakModel.name)
-        fitElement.set("integrate", str(fit.fitter.peakModel.fOptStatus["integrate"]))
-        fitElement.set("likelihood", fit.fitter.peakModel.fOptStatus["likelihood"])
+        for opt, status in fit.fitter.peakModel.fOptStatus.items():
+            fitElement.set(opt, str(status))
         fitElement.set("nParams", str(fit.fitter.backgroundModel.fParStatus["nparams"]))
         fitElement.set("chi", str(fit.chi))
         # <spectrum>
@@ -631,9 +631,9 @@ class FitXml:
         fitter = Fitter(peakModel, backgroundModel)
         fit = Fit(fitter, cal=calibration)
 
-        for parname in ["integrate", "likelihood"]:
-            if parname in fitElement.attrib:
-                fitter.SetParameter(parname, fitElement.get(parname))
+        for opt in fitter.peakModel.fOptStatus:
+            if opt in fitElement.attrib:
+                fitter.SetParameter(opt, fitElement.get(opt))
         try:
             fit.chi = float(fitElement.get("chi"))
         except ValueError:

--- a/hdtv/peakmodels/theuerkaufPeak.py
+++ b/hdtv/peakmodels/theuerkaufPeak.py
@@ -191,10 +191,12 @@ class PeakModelTheuerkauf(PeakModel):
         self.fOptStatus = {
             "integrate": False,
             "likelihood": "normal",
+            "onlypositivepeaks": False,
         }
         self.fValidOptStatus = {
             "integrate": [False, True],
             "likelihood": ["normal", "poisson"],
+            "onlypositivepeaks": [False, True],
         }
 
         self.ResetParamStatus()
@@ -277,6 +279,7 @@ class PeakModelTheuerkauf(PeakModel):
         self.fParStatus["sw"] = "hold"
         self.fOptStatus["integrate"] = False
         self.fOptStatus["likelihood"] = "normal"
+        self.fOptStatus["onlypositivepeaks"] = False
 
     def Uncal(self, parname, value, pos_uncal, cal):
         """
@@ -308,8 +311,9 @@ class PeakModelTheuerkauf(PeakModel):
         # self.fFitter = ROOT.HDTV.Fit.TheuerkaufFitter(region[0],region[1],debug_show_inipar)
         integrate = self.GetOption("integrate")
         likelihood = self.GetOption("likelihood")
+        onlypositivepeaks = self.GetOption("onlypositivepeaks")
         self.fFitter = ROOT.HDTV.Fit.TheuerkaufFitter(
-            region[0], region[1], integrate, likelihood
+            region[0], region[1], integrate, likelihood, onlypositivepeaks
         )
         self.ResetGlobalParams()
         # Check if enough values are provided in case of per-peak parameters

--- a/hdtv/plugins/fitInterface.py
+++ b/hdtv/plugins/fitInterface.py
@@ -59,6 +59,13 @@ class FitInterface:
         )
         hdtv.options.RegisterOption("fit.display.decomp", self.opt["display.decomp"])
 
+        self.opt["list.show_pos_lit_residuals"] = hdtv.options.Option(
+            default=False, parse=hdtv.options.parse_bool
+        )
+        hdtv.options.RegisterOption(
+            "fit.list.show_pos_lit_residuals", self.opt["list.show_pos_lit_residuals"]
+        )
+
         if self.window:
             self._register_hotkeys()
 
@@ -353,7 +360,13 @@ class FitInterface:
                 # do not use set operations here to keep order of params
                 if p not in params:
                     params.append(p)
+                    if self.opt["list.show_pos_lit_residuals"].Get() and p == "pos_lit":
+                        params.append("Δpos_lit")
             # add peaks to the list
+            if self.opt["list.show_pos_lit_residuals"].Get() and "Δpos_lit" in params:
+                for peak in peaklist:
+                    if "pos_lit" in peak:
+                        peak["Δpos_lit"] = peak["pos_lit"] - peak["pos"]
             fitlist.extend(peaklist)
         return (fitlist, params)
 

--- a/hdtv/plugins/fitInterface.py
+++ b/hdtv/plugins/fitInterface.py
@@ -597,7 +597,7 @@ class TvFitInterface:
         self.spectra = self.fitIf.spectra
 
         # Register configuration variables for fit list
-        opt = hdtv.options.Option(default="ID")
+        opt = hdtv.options.Option(default="id")
         hdtv.options.RegisterOption("fit.list.sort_key", opt)
 
         prog = "fit execute"
@@ -1249,7 +1249,7 @@ class TvFitInterface:
         # parse sort_key
         if args.key_sort is None:
             args.key_sort = hdtv.options.Get("fit.list.sort_key")
-        key_sort = args.key_sort.lower()
+        key_sort = args.key_sort
         for sid in sids:
             spec = self.spectra.dict[sid]
             ids = hdtv.util.ID.ParseIds(args.fit, spec)
@@ -1273,7 +1273,7 @@ class TvFitInterface:
             hdtv.ui.warning("No spectra chosen or active")
             return
         # parse sort_key
-        key_sort = args.key_sort.lower()
+        key_sort = args.key_sort
         for sid in sids:
             spec = self.spectra.dict[sid]
             ids = hdtv.util.ID.ParseIds(args.fit, spec)

--- a/hdtv/rootext/fit/Fitter.cc
+++ b/hdtv/rootext/fit/Fitter.cc
@@ -37,13 +37,21 @@ Param Fitter::AllocParam() { return Param::Free(fNumParams++); }
 
 Param Fitter::AllocParam(double ival) { return Param::Free(fNumParams++, ival); }
 
-void Fitter::SetParameter(TF1 &func, Param &param, double ival) {
+void Fitter::SetParameter(TF1 &func, Param &param, double ival, bool useLimits, double lowerLimit, double upperLimit) {
+  if (useLimits && param.IsFree()) {
+    ival = ival < lowerLimit ? lowerLimit : ival > upperLimit ? upperLimit : ival;
+  }
   if (!param.HasIVal()) {
     param.SetValue(ival);
   }
 
   if (param.IsFree()) {
-    func.SetParameter(param._Id(), param._Value());
+    if (useLimits) {
+      func.SetParameter(param._Id(), param._Value());
+      func.SetParLimits(param._Id(), lowerLimit, upperLimit);
+    } else {
+      func.SetParameter(param._Id(), param._Value());
+    }
   }
 }
 

--- a/hdtv/rootext/fit/Fitter.hh
+++ b/hdtv/rootext/fit/Fitter.hh
@@ -23,6 +23,7 @@
 #ifndef __Fitter_h__
 #define __Fitter_h__
 
+#include <limits>
 #include <memory>
 
 #include "Background.hh"
@@ -59,7 +60,9 @@ protected:
   std::unique_ptr<TF1> fBgFunc;
   double fChisquare;
 
-  void SetParameter(TF1 &func, Param &param, double ival = 0.0);
+  void SetParameter(TF1 &func, Param &param, double ival = 0.0, bool useLimits = false,
+                    double lowerLimit = std::numeric_limits<double>::min(),
+                    double upperLimit = std::numeric_limits<double>::max());
 };
 
 } // end namespace Fit

--- a/hdtv/rootext/fit/TheuerkaufFitter.hh
+++ b/hdtv/rootext/fit/TheuerkaufFitter.hh
@@ -141,8 +141,9 @@ private:
 class TheuerkaufFitter : public Fitter {
 public:
   TheuerkaufFitter(double r1, double r2, Option<bool> integrate, Option<std::string> likelihood,
-                   bool debugShowInipar = false)
-      : Fitter(r1, r2), fIntegrate(integrate), fLikelihood(likelihood), fDebugShowInipar(debugShowInipar) {}
+                   Option<bool> onlypositivepeaks, bool debugShowInipar = false)
+      : Fitter(r1, r2), fIntegrate(integrate), fLikelihood(likelihood), fOnlypositivepeaks(onlypositivepeaks),
+        fDebugShowInipar(debugShowInipar) {}
 
   // Copying the fitter is not supported
   TheuerkaufFitter(const TheuerkaufFitter &) = delete;
@@ -172,6 +173,7 @@ private:
   std::vector<TheuerkaufPeak> fPeaks;
   Option<bool> fIntegrate;
   Option<std::string> fLikelihood;
+  Option<bool> fOnlypositivepeaks;
   bool fDebugShowInipar;
 };
 

--- a/hdtv/util.py
+++ b/hdtv/util.py
@@ -298,8 +298,6 @@ class Table:
             self.header = header
         # initial width of columns
         for header in self.header:
-            # TODO: len fails on unicode characters (e.g. σ) ->
-            # str.decode(encoding)
             self._col_width.append(len(str(header)) + 2)
 
     def build_lines(self):
@@ -331,8 +329,6 @@ class Table:
                         self._ignore_col[i] = False
 
                     line.append(value)
-                    # TODO: len fails on unicode characters (e.g. σ) -> str.decode(encoding)
-                    # Store maximum col width
                     if self.raw_columns and key in self.raw_columns:
                         self._col_width[i] = max(
                             self._col_width[i], len(strip_tags(value)) + 2
@@ -360,8 +356,6 @@ class Table:
         # Determine table widths
         for w in self._col_width:
             self._width += w
-            # TODO: for unicode awareness we have to do something
-            #       like len(col_sep_char.decode('utf-8')
             self._width += len(self.col_sep_char)
 
     def build_header(self):
@@ -829,8 +823,17 @@ def open_compressed(fname, mode="rb", **kwargs):
         )
 
 
-def natural_sort_key(s, _nsre=re.compile("([0-9]+)")):
-    return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]
+def natural_sort_key(s, _nsre=re.compile(r"([-+]?[0-9]+\.?[0-9]*)")):
+    # Split string into list of strings and floats for sorting.
+    # The result of the split will always be an alternating list of strings and
+    # floats (still in string form), always starting with a (possibly empty) string
+    # as the first element.
+    # Hence, convert all even elements to floats and all odd elements to lower case
+    # strings.
+    return [
+        float(part) if (i % 2) else part.lower()
+        for i, part in enumerate(_nsre.split(s))
+    ]
 
 
 class Singleton(type):


### PR DESCRIPTION
`fit read` now takes the same default value as `fit write` when no file was explicitly given.
This for example allows to easily restore a lot of default-named fits using `fit read -s all` without the need of `fit getlists` and its extra file.

The initial fit value for the width is now set up to always be positive to avoid the ROOT fitter to fit regular peaks with negative widths and volumes.
This could happen before in certain cases with low statistics peaks.

Added a fit parameter option `onlypositivepeaks` to the Theuerkauf peak model, which if set to true tells the underlying ROOT fitter to only allow positive peak widths and volumes in the fit.

A new config setting `ui.bellOnNextAndPrevIDEndReached` allows the terminal to emit a bell character when the result of the special IDs next and prev is the first or last ID again.
When for example browsing through many spectra one by one this gives the user audible/visual feedback that they reached the end of the spectra list.

A new config setting `fit.list.show_pos_lit_residuals` lets `fit list` also list the pos_lit - pos residuals in the fit list table (before the only way to see them was performing a full recalibration).

The `calibration position recalibrate` command now takes an optional argument to specify which peaks/fits to use for the calibration.

Finally, a bug with the fit function and residual plots not showing was fixed and natural sorting was improved to deal with negative numbers and floats.