### PR TITLE
rootext/mfile-root: Fix missing cmath include

### DIFF
--- a/hdtv/rootext/mfile-root/VMatrix.hh
+++ b/hdtv/rootext/mfile-root/VMatrix.hh
@@ -23,6 +23,7 @@
 #ifndef __VMatrix_h__
 #define __VMatrix_h__
 
+#include <cmath>
 #include <list>
 
 #include <TH1.h>


### PR DESCRIPTION
In rootext/mfile-root/VMatrix.hh `std::ceil` requires `cmath` which is missing. Add the include. to fix this build error.

I got this error using GCC 14.3.0 and Clang 21.1.2 and ROOT 6.38.00 after an update on NixOS.