### PR TITLE
ruff: Add PLW0108 to ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ lint.ignore = [
     "PLW1641",
     "PLW2901",
     "PLW0642",
+    "PLW0108",
     "RUF012",  # enforces type annotations on a codebase that lacks type annotations
     "B904",
     "ISC001",


### PR DESCRIPTION
Ruff 0.15.0 added the unnecessary-lambda (PLW0108) check [1].

It is another check for best practices, but an automatic fix is not always safe and requires knowledge of the affected code.

Disable the check for now to not introduce a regression while trying to fix it.

[1] https://docs.astral.sh/ruff/rules/unnecessary-lambda/