### PR TITLE
GitHub Actions: Fix CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: '0 22 * * 1'
 
+permissions:
+  contents: read
+  security-events: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
The CodeQL workflow needs a permission section to run.
---
This should fix https://github.com/hdtv-tool/hdtv/actions/runs/22079461673. But it needs to get merged to see if it's actually working