### PR TITLE
 GitHub Actions: Fix CodeQL workflow (2)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
 
 permissions:
   contents: read
-  security-events: read
+  security-events: write
 
 jobs:
   analyze:


### PR DESCRIPTION
 Ok, the `security-events` has to be set to `write`

---

This time I've tested the push on my fork. 