### PR TITLE
fix: printing of calibrated spectra now uses correct numpy function

### DIFF
--- a/src/hdtv/plugins/printing.py
+++ b/src/hdtv/plugins/printing.py
@@ -19,7 +19,6 @@
 
 import matplotlib
 import numpy
-import scipy
 
 matplotlib.use("agg")  # Must be before import pylab!
 import pylab

--- a/src/hdtv/plugins/printing.py
+++ b/src/hdtv/plugins/printing.py
@@ -186,9 +186,9 @@ class PrintOut:
         """
         if cal and not cal.IsTrivial():
             calpolynom = hdtv.cal.GetCoeffs(cal)
-            # scipy needs highes order first
+            # numpy needs highes order first
             calpolynom.reverse()
-            en = scipy.polyval(calpolynom, en)
+            en = numpy.polyval(calpolynom, en)
         return en
 
 


### PR DESCRIPTION
As outlined in issue #39, using `print` on a calibrated spectrum was not working. 

Creation of the calibration polynomial tried to use a non-existent scipy function `scipy.polyval`. 

Changed this to numpy method `numpy.polyval` with intended functionality. Tested with commands shown in the issue. 